### PR TITLE
chore: bump modern warp menu

### DIFF
--- a/oneclient/mrpacks/1.21.11-fabric/SkyBlock/mods/modern-warp-menu.pw.toml
+++ b/oneclient/mrpacks/1.21.11-fabric/SkyBlock/mods/modern-warp-menu.pw.toml
@@ -6,11 +6,11 @@ filename = "modernwarpmenu-0.1.9+1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/3GNyRk4I/versions/9VbNawGb/modernwarpmenu-0.1.9%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/3GNyRk4I/versions/XgWqk8ik/modernwarpmenu-0.2.2%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "d777b32fe73b21e21efe359f010909c02799032312641b070d4d5ade0822bd1009215761e3118ac1991dd530a1eeb35180fad1c9d73c7e282bac4b5289ed6c0e"
+hash = "f7cd03d7430ed831a9289f6f12178fd2161add40eabcce83e099430fd964e4ced97d9de23150eea73bdd1fd8e3ee7af579ddf3a5e719a68f2fca58f8ac2ee2b3"
 
 [update]
 [update.modrinth]
 mod-id = "3GNyRk4I"
-version = "9VbNawGb"
+version = "XgWqk8ik"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

see https://discord.com/channels/822066990423605249/1515956502333100042/1515959046916669602
see https://github.com/Yukkuritaku/ModernWarpMenu/issues/29

mod also needs to be updated to fix https://github.com/Yukkuritaku/ModernWarpMenu/issues/28

tldr modern warp menu releases its versions as an alpha instead of a full release

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->